### PR TITLE
Move application worker definition to the top level of a module

### DIFF
--- a/pytest_flask/fixtures.py
+++ b/pytest_flask/fixtures.py
@@ -41,6 +41,10 @@ def client_class(request, client):
         request.cls.client = client
 
 
+def _app_worker(app, port):
+    app.run(port=port, use_reloader=False)
+
+
 class LiveServer(object):
     """The helper class uses to manage live server. Handles creation and
     stopping application in a separate process.
@@ -56,10 +60,8 @@ class LiveServer(object):
 
     def start(self):
         """Start application in a separate process."""
-        def worker(app, port):
-            app.run(port=port, use_reloader=False)
         self._process = multiprocessing.Process(
-            target=worker,
+            target=_app_worker,
             args=(self.app, self.port)
         )
         self._process.start()


### PR DESCRIPTION
As per https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled
the only top level function can be pickled. Re #54.